### PR TITLE
Add protected route tests

### DIFF
--- a/__tests__/App.test.tsx
+++ b/__tests__/App.test.tsx
@@ -1,8 +1,9 @@
 import React from 'react';
 import { render, screen } from '@testing-library/react';
-import App from '../client/src/App';
-
 // Mock dependencies
+const useLocationMock = jest.fn();
+const useAuthMock = jest.fn();
+
 jest.mock('@tanstack/react-query', () => ({
   QueryClientProvider: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
 }));
@@ -13,8 +14,15 @@ jest.mock('../client/src/lib/queryClient', () => ({
 
 jest.mock('wouter', () => ({
   Switch: ({ children }: { children: React.ReactNode }) => <div data-testid="switch">{children}</div>,
-  Route: ({ path }: { path: string }) => <div data-testid={`route-${path}`} />,
-  useLocation: () => ['/'],
+  Route: ({ path, component: Component, children }: { path: string; component?: React.FC; children?: React.ReactNode }) => (
+    <div data-testid={`route-${path}`}>{Component ? <Component /> : children}</div>
+  ),
+  Redirect: ({ to }: { to: string }) => <div data-testid={`redirect-${to}`} />,
+  useLocation: () => useLocationMock(),
+}));
+
+jest.mock('../client/src/hooks/useAuth', () => ({
+  useAuth: () => useAuthMock(),
 }));
 
 jest.mock('../client/src/context/user-context', () => ({
@@ -34,7 +42,18 @@ jest.mock('../client/src/components/ui/toaster', () => ({
   Toaster: () => <div data-testid="toaster" />,
 }));
 
+jest.mock('../client/src/pages/decision-log', () => ({
+  __esModule: true,
+  default: () => <div data-testid="decision-log-page">Decision Log</div>,
+}));
+
+import App from '../client/src/App';
+
 describe('App Component', () => {
+  beforeEach(() => {
+    useLocationMock.mockReturnValue(['/']);
+    useAuthMock.mockReset();
+  });
   it('renders without crashing', () => {
     render(<App />);
     expect(screen.getByTestId('user-provider')).toBeInTheDocument();
@@ -42,5 +61,19 @@ describe('App Component', () => {
     expect(screen.getByTestId('page-transition')).toBeInTheDocument();
     expect(screen.getByTestId('switch')).toBeInTheDocument();
     expect(screen.getByTestId('toaster')).toBeInTheDocument();
+  });
+
+  it('redirects to login when navigating to a protected route while unauthenticated', () => {
+    useAuthMock.mockReturnValue({ isAuthenticated: false, isLoading: false });
+    useLocationMock.mockReturnValue(['/decision-log']);
+    render(<App />);
+    expect(screen.getByTestId('redirect-/login')).toBeInTheDocument();
+  });
+
+  it('renders the protected component when authenticated', () => {
+    useAuthMock.mockReturnValue({ isAuthenticated: true, isLoading: false });
+    useLocationMock.mockReturnValue(['/decision-log']);
+    render(<App />);
+    expect(screen.getByTestId('decision-log-page')).toBeInTheDocument();
   });
 });


### PR DESCRIPTION
## Summary
- update App.test.tsx to support protected route tests
- mock `useAuth` and `useLocation` to simulate authentication and routing
- verify redirects for unauthenticated users and page rendering for authenticated users

## Testing
- `npm test` *(fails: Missing script "test")*
- `npx --no-install jest` *(fails: 403 Forbidden when retrieving jest)*

------
https://chatgpt.com/codex/tasks/task_e_6849c1d0bb288324b83fca08326256d0