### PR TITLE
Fix spelling in vite server comment

### DIFF
--- a/server/vite.ts
+++ b/server/vite.ts
@@ -65,7 +65,7 @@ export async function setupVite(app: Express, server: Server) {
         "index.html",
       );
 
-      // always reload the index.html file from disk incase it changes
+      // reload the index.html file from disk *in case* it changes
       let template = await fs.promises.readFile(clientTemplate, "utf-8");
       template = template.replace(
         `src="/src/main.tsx"`,


### PR DESCRIPTION
## Summary
- fix a typo in the Vite server setup comment

## Testing
- `npm run check` *(fails: Cannot find type definition file for 'node')*

------
https://chatgpt.com/codex/tasks/task_e_6849c1c8c52c83249913195fce1b540e